### PR TITLE
remove profile opts arg

### DIFF
--- a/index.js
+++ b/index.js
@@ -341,10 +341,10 @@ Vector.prototype.getInfo = function(callback) {
     return callback(null, this._info);
 };
 
-Vector.prototype.profile = function(opts, callback) {
+Vector.prototype.profile = function(callback) {
     var map = new mapnik.Map(256,256);
     var mapFromStringStart = Date.now();
-    map.fromString(opts.xml, {
+    map.fromString(this._xml, {
         strict: false,
         base: this._base + '/'
     }, function(err) {


### PR DESCRIPTION
Essentially a bug fix, Vector.prototype.profile should profile itself, not whatever XML string gets passed into it. What sort of version bump would this require per semver?

/cc @yhahn
