### PR TITLE
Allow an existing tilelive instance to be injected

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,14 @@ function md5(str) {
 };
 
 function Vector(uri, callback) {
+    // since this needs to be called as a constructor to be used as a Source,
+    // cheat and use the fact that it's being called as a function to inject
+    // dependencies
+    if (!(this instanceof Vector)) {
+        tilelive = arguments[0];
+        return Vector;
+    }
+
     if (!uri.xml) return callback && callback(new Error('No xml'));
 
     this._uri = uri;


### PR DESCRIPTION
...via Vector = require("tilelive-vector")(tilelive)

While removing the local `tilelive` dependency seems like a positive long-term change, this implementation doesn't impact existing usage.

`Backend` still requires `tilelive` directly, so this is only a partial fix.

(This addresses the `npm link` use-case where different copies of `tilelive` are loaded and the registries differ.)
