### PR TITLE
Report autoscale: true

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,6 +246,9 @@ Vector.prototype.getInfo = function(callback) {
         }
         return memo;
     }, {});
+
+    this._info.autoscale = true;
+
     return callback(null, this._info);
 };
 


### PR DESCRIPTION
`tilelive-vector` renders scale-dependent tiles, so it supports `autoscale`.
