### PR TITLE
Evil version of detecting mapnik vector tiles from upstream backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "dependencies": {
     "mapnik": "~1.4.10",
+    "tiletype": "git+https://github.com/mapbox/tiletype.git#content-encoding-evil",
     "tilelive": "5.0.x",
     "tar": "~0.1.18",
     "request": "~2.27.0",
@@ -24,7 +25,7 @@
   },
   "devDependencies": {
     "tape": "2.13.x",
-    "tilejson": "git+https://github.com/mapbox/node-tilejson.git#content-encoding",
+    "tilejson": "git+https://github.com/mapbox/node-tilejson.git#content-encoding-evil",
     "simple-statistics": "~0.8.0"
   },
   "scripts": {

--- a/test/testsource.js
+++ b/test/testsource.js
@@ -73,7 +73,7 @@ var tiles = {
 };
 
 // Additional error tile fixtures.
-tiles.a['1.0.3'] = new Buffer('asdf'); // invalid protobuf
+tiles.a['1.0.3'] = tiles.a['0.0.0'].slice(0,50); // invalid protobuf
 tiles.a['0.0.1'] = new Buffer(0); // empty protobuf
 
 Testsource.now = new Date;


### PR DESCRIPTION
Removes trust of content-type header from https://github.com/mapbox/tilelive-vector/pull/69.
