### PR TITLE
Upgrade to latest node-mapnik APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.4.0
+
+ - Updated to use mapnik 3.4.6
+
 ## 3.2.7
 
  - Update tilelive.js to 5.8.x

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     }
   ],
   "dependencies": {
-    "mapnik" : "~3.4.1",
+    "mapnik": "https://github.com/mapnik/node-mapnik/tarball/master",
     "tilelive": "5.8.x",
     "tar": "~0.1.18",
     "request": "~2.48.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilelive-vector",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "main": "./index.js",
   "description": "Vector tile => raster tile backend for tilelive",
   "repository": {
@@ -13,7 +13,7 @@
     }
   ],
   "dependencies": {
-    "mapnik": "https://github.com/mapnik/node-mapnik/tarball/master",
+    "mapnik": "~3.4.6",
     "tilelive": "5.8.x",
     "tar": "~0.1.18",
     "request": "~2.48.0",

--- a/test/backend.js
+++ b/test/backend.js
@@ -1,7 +1,6 @@
 var test = require('tape');
 var tilelive = require('tilelive');
 var url = require('url');
-var zlib = require('zlib');
 var Backend = require('..').Backend;
 var mapnik = require('..').mapnik;
 var path = require('path');
@@ -160,8 +159,11 @@ tilelive.protocols['test:'] = Testsource;
     });
     test('errors out on bad protobuf', function(t) {
         sources.a.getTile(1, 0, 3, function(err, vtile) {
-            t.equal('could not parse buffer as protobuf', err.message);
-            t.end();
+            t.ifError(err);
+            vtile.parse(function(err) {
+                t.equal('could not parse buffer as protobuf', err.message);
+                t.end();
+            });
         });
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,6 @@
 var test = require('tape');
 var tilelive = require('tilelive');
 var url = require('url');
-var zlib = require('zlib');
 var Vector = require('..');
 var path = require('path');
 var fs = require('fs');
@@ -262,7 +261,7 @@ test('errors out on bad deflate', function(t) {
 });
 test('errors out on bad protobuf', function(t) {
     sources.a.getTile(1, 0, 3, function(err) {
-        t.equal('could not parse buffer as protobuf', err.message);
+        t.equal('end of buffer exception', err.message);
         t.end();
     });
 });


### PR DESCRIPTION
 - Stops calling `vtile.parse()` which is no longer needed and avoids this overhead
 - Stops decompressing buffer - node-mapnik can now consume zlib inflate or gzipped data directly (avoids uncompressed buffer being passing through JS)

Companion to https://github.com/mapbox/tilelive-bridge/pull/59