### PR TITLE
Add support for loading tm2z from s3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,20 @@
 language: node_js
-
 node_js:
-  - "0.10"
-  - "0.12"
-
+- '0.10'
+- '0.12'
 addons:
   apt:
     sources:
-     - ubuntu-toolchain-r-test
+    - ubuntu-toolchain-r-test
     packages:
-     - libstdc++6 # upgrade libstdc++ on linux to support C++11
-
+    - libstdc++6
 env:
   global:
-  - secure: "Ud6+6DgQtUHMf//2loICXJQzKD0cEX2cZGm2Ty9VOttEOaZXq8Z6Kw0QVOf4g5pglfS9E+IprHDGzzuwmhzz0HPafRb6/gFZU2Euj+3nsHZYhbPj5HZTRXjzZXhP6tPbQ1E7Wg6uPvKR9YbFTXC8njPqeEAo2dS6TTcIIB7zu/I="
-
+  - secure: Ud6+6DgQtUHMf//2loICXJQzKD0cEX2cZGm2Ty9VOttEOaZXq8Z6Kw0QVOf4g5pglfS9E+IprHDGzzuwmhzz0HPafRb6/gFZU2Euj+3nsHZYhbPj5HZTRXjzZXhP6tPbQ1E7Wg6uPvKR9YbFTXC8njPqeEAo2dS6TTcIIB7zu/I=
+  - secure: Z7g8V0gOqE1r0GyT8NxI7EsjLixC/YlI22iH6n9Ar92X0Dhc7N2wS5FNKILMIICLzJGvCFFA/oc15qcDfkDDeUwq7uGs2cxdTinKZwbGPnfEJ1nuK6VdJfmfdIepGUaiOMQg5UyM8Zi8RBzaW2vP6DO/6Q7a4G0J/V3GNcE1hYg=
+  - secure: N/oZKx7VKaWdhjQhwRPnO1UfjAmuGE3bmB+4lmGTkEoupo5/g1O2V5bPqPoMQqjQEOlRTZqXx4zu9yF/Ew8Ie7Ra35tNbKYz84xS+5UIK/5FgOshi5z1H+nyzs18oTrM1b5cYqAU14eyaEdUD01Vl30dWAD0MfWbVb9fNdLq+8o=
+  - secure: A2YjZ6wxGMAA8Cn6UCIBrySqSjuGjQ7XG6kGPabDT6bvXsiWG0wUi6ZqvjM1HL8S9uc5ZoGWZzrIyRYOTwuX100pOn4JjAphyzYD8fN+6etuq+6s8w6kJI7ENzd7d449aXpRQOYGEW3WoApzbGoRk9EHfHhxfHArgwohzBxjFcg=
+  - secure: CMwaxidCWlxccrPByDsEOcyJ+W6pjXwufb8s8Pe9YecnpEp+ppr6eK5/AYP9bor5QJwS8G/m0JOwDA8Pzn6vhOn/GXCamBCYHtTZPhliYWt9b81ZJbaoqSzJgtkUgyU9DzOkgDa6SJ+jRAmdtcDgDbRcadI7rsA/YVFxeO+mxI0=
 sudo: false
-
 after_success:
- - if [[ ${TRAVIS_NODE_VERSION} == "0.10" ]]; then npm run coverage; fi;
+- if [[ ${TRAVIS_NODE_VERSION} == "0.10" ]]; then npm run coverage; fi;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,10 @@ environment:
     - nodejs_version: 0.12.7
   MapboxAccessToken:
     secure: 01rO70zKIKzh2l8htHugNS3cCk9u3LfTu2SXojFaYkveumhZRDgRrH/BroS+fIv8T6YB5l0P2nvKAjqhdDW2yuaLWGIB5KdBmhywp4dXa0g=
+  AWS_ACCESS_KEY_ID:
+    secure: OBZOTIMd7fPLEMiTp6wqBPxDdh89++4el/PFz2PU7uo=
+  AWS_SECRET_ACCESS_KEY:
+    secure: 3J9cHNPVgtrqmUufBdyKPqqSeSq4H5IfvKlbuyHG4h5jfKsa24gBjSNBaeKeAXl5
 
 platform:
   - x64

--- a/cloudformation/travis.template
+++ b/cloudformation/travis.template
@@ -1,0 +1,53 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "tilelive-vector build resources",
+    "Resources": {
+        "BuildUser": {
+            "Type": "AWS::IAM::User",
+            "Properties": {
+                "Policies": [
+                    {
+                        "PolicyName": "test",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Action": [
+                                        "s3:HeadObject",
+                                        "s3:GetObject"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Resource": [
+                                        "arn:aws:s3:::mapbox/tilelive-vector/*"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "BuildUserKey": {
+            "Type": "AWS::IAM::AccessKey",
+            "Properties": {
+                "UserName": {
+                    "Ref": "BuildUser"
+                }
+            }
+        }
+    },
+    "Outputs": {
+        "AccessKeyId": {
+            "Value": {
+                "Ref": "BuildUserKey"
+            }
+        },
+        "SecretAccessKey": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "BuildUserKey",
+                    "SecretAccessKey"
+                ]
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     }
   ],
   "dependencies": {
+    "aws-sdk": "^2.2.30",
+    "s3urls": "^1.3.0",
     "mapnik": "~3.4.6",
     "tilelive": "5.11.x",
     "tiletype": "0.3.x",

--- a/test/tm2z.js
+++ b/test/tm2z.js
@@ -286,3 +286,23 @@ test('errors out on an invalid S3 url', function(t) {
     });
 });
 
+test('errors out on private object with tm2z+http protocol', function(t) {
+    tilelive.load('tm2z+http://mapbox.s3.amazonaws.com/tilelive-vector/test-tm2z-private.tm2z', function(err, source) {
+        t.equal('Z_DATA_ERROR', err.code);
+        t.end();
+    });
+});
+
+test('load private tm2z from s3 using tm2z+s3 protocol', function(t) {
+    tilelive.load('tm2z+s3://mapbox/tilelive-vector/test-tm2z-private.tm2z', function(err, source) {
+        t.ifError(err);
+        t.end();
+    });
+});
+
+test('errors out on tm2z file on s3 where we do not have access', function(t) {
+    tilelive.load('tm2z+s3://example/does-not-exist.tm2z', function(err, source) {
+        t.equal(err.code, 'AccessDenied');
+        t.end();
+    });
+});


### PR DESCRIPTION
Add `tm2z+s3` protocol support, which uses aws-sdk to localize/unpack tm2z files.

- [x] tests
- [x] add encrypted aws credentials to appveyor

/cc @yhahn 