### PR TITLE
allow for process.env.NO_AUTH to skip test that require credentials

### DIFF
--- a/test/tm2z.js
+++ b/test/tm2z.js
@@ -13,8 +13,8 @@ function md5(str) {
 }
 
 // skip tests that require s3 authentication if necessary
-// use ~$ NO_AUTH=true npm test
-var NO_AUTH = (process.env.NO_AUTH) ? process.env.NO_AUTH : false;
+// use ~$ TILELIVE_VECTOR_NO_AUTH=true npm test
+var TILELIVE_VECTOR_NO_AUTH = (process.env.TILELIVE_VECTOR_NO_AUTH) ? process.env.TILELIVE_VECTOR_NO_AUTH : false;
 
 // Load fixture data.
 var fixtureDir = path.resolve(__dirname, 'fixtures', 'tm2z'),
@@ -290,21 +290,21 @@ test('errors out on an invalid S3 url', function(t) {
     });
 });
 
-test('errors out on private object with tm2z+http protocol', {skip: NO_AUTH}, function(t) {
+test('errors out on private object with tm2z+http protocol', {skip: TILELIVE_VECTOR_NO_AUTH}, function(t) {
     tilelive.load('tm2z+http://mapbox.s3.amazonaws.com/tilelive-vector/test-tm2z-private.tm2z', function(err, source) {
         t.equal('Z_DATA_ERROR', err.code);
         t.end();
     });
 });
 
-test('load private tm2z from s3 using tm2z+s3 protocol', {skip: NO_AUTH}, function(t) {
+test('load private tm2z from s3 using tm2z+s3 protocol', {skip: TILELIVE_VECTOR_NO_AUTH}, function(t) {
     tilelive.load('tm2z+s3://mapbox/tilelive-vector/test-tm2z-private.tm2z', function(err, source) {
         t.ifError(err);
         t.end();
     });
 });
 
-test('errors out on tm2z file on s3 where we do not have access', {skip: NO_AUTH}, function(t) {
+test('errors out on tm2z file on s3 where we do not have access', {skip: TILELIVE_VECTOR_NO_AUTH}, function(t) {
     tilelive.load('tm2z+s3://example/does-not-exist.tm2z', function(err, source) {
         t.equal(err.code, 'AccessDenied');
         t.end();

--- a/test/tm2z.js
+++ b/test/tm2z.js
@@ -12,6 +12,10 @@ function md5(str) {
     return crypto.createHash('md5').update(str).digest('hex');
 }
 
+// skip tests that require s3 authentication if necessary
+// use ~$ NO_AUTH=true npm test
+var NO_AUTH = (process.env.NO_AUTH) ? process.env.NO_AUTH : false;
+
 // Load fixture data.
 var fixtureDir = path.resolve(__dirname, 'fixtures', 'tm2z'),
     remotePath = 'http://mapbox.s3.amazonaws.com/tilelive-vector/test-tm2z.tm2z',
@@ -286,21 +290,21 @@ test('errors out on an invalid S3 url', function(t) {
     });
 });
 
-test('errors out on private object with tm2z+http protocol', function(t) {
+test('errors out on private object with tm2z+http protocol', {skip: NO_AUTH}, function(t) {
     tilelive.load('tm2z+http://mapbox.s3.amazonaws.com/tilelive-vector/test-tm2z-private.tm2z', function(err, source) {
         t.equal('Z_DATA_ERROR', err.code);
         t.end();
     });
 });
 
-test('load private tm2z from s3 using tm2z+s3 protocol', function(t) {
+test('load private tm2z from s3 using tm2z+s3 protocol', {skip: NO_AUTH}, function(t) {
     tilelive.load('tm2z+s3://mapbox/tilelive-vector/test-tm2z-private.tm2z', function(err, source) {
         t.ifError(err);
         t.end();
     });
 });
 
-test('errors out on tm2z file on s3 where we do not have access', function(t) {
+test('errors out on tm2z file on s3 where we do not have access', {skip: NO_AUTH}, function(t) {
     tilelive.load('tm2z+s3://example/does-not-exist.tm2z', function(err, source) {
         t.equal(err.code, 'AccessDenied');
         t.end();


### PR DESCRIPTION
Per https://github.com/mapbox/mapnik-swoop/issues/9 this adds a check for `process.env.NO_AUTH` in `test/tm2z.js` in order to skip tests that require s3 authorization. 

I wasn't exactly sure which route is best here, but liked the idea from @springmeyer to pass `NO_AUTH` as a parameter on execution like:

```bash
$ NO_AUTH=true npm test
```

This changes parameters in three tests by adding `{skip: NO_AUTH}`, which skips the test if it is set to `true`, otherwise it continues running through.

**Alternative strategy**: We could also just wrap the tests within an `if (NO_AUTH)` if that makes more sense?

cc/ @willwhite for :eyes: 