### PR TITLE
Allow tilelive 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilelive-vector",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "main": "./index.js",
   "description": "Vector tile => raster tile backend for tilelive",
   "repository": {
@@ -16,7 +16,7 @@
     "aws-sdk": "^2.2.30",
     "s3urls": "^1.3.0",
     "mapnik": "~3.4.6",
-    "tilelive": "5.11.x",
+    "tilelive": "5.x",
     "tiletype": "0.3.x",
     "tar": "~2.2.1",
     "request": "~2.65.0",


### PR DESCRIPTION
Most apps that depend on tilelive-vector pin their own version of `tilelive`. So, this change allows for them to get their desired version of tilelive without dupes.