### PR TITLE
Close the give tilesource, iff it can do so

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -164,3 +164,12 @@ Backend.prototype.getTile = function(z, x, y, callback) {
     };
 };
 
+Backend.prototype.close = function(callback) {
+    if (!this._source) return callback(new Error('Tilesource not loaded'));
+
+    if (typeof this._source.close === 'function') {
+        return this._source.close(callback);
+    }
+
+    return callback(null);
+};

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ Vector.prototype.open = function(callback) {
 };
 
 Vector.prototype.close = function(callback) {
-    return callback();
+    return this._backend.close(callback);
 };
 
 // Allows in-place update of XML/backends.

--- a/test/backend.js
+++ b/test/backend.js
@@ -168,6 +168,15 @@ tilelive.protocols['test:'] = Testsource;
             });
         });
     });
+    test('close is called on source', function(t) {
+        var testsource = new Testsource('a');
+        new Backend({ source:testsource }, function(err, backend) {
+            backend.close(function(err) {
+                t.equal(testsource.closeCalled, true);
+                t.end();
+            });
+        });
+    });
 
 function replacer(key, value) {
     if (key === 'raster') {

--- a/test/test.js
+++ b/test/test.js
@@ -301,3 +301,11 @@ test('diff scale => diff ETags', function(t) {
     t.end();
 });
 
+test('source should be closed', function(t) {
+    new Vector({ source:'test:///a', xml: xml.a }, function(err, source) {
+        source.close(function(err) {
+            t.equal(source._backend._source.closeCalled, true);
+            t.end();
+        });
+    });
+});

--- a/test/testsource.js
+++ b/test/testsource.js
@@ -138,6 +138,7 @@ function Testsource(uri, callback) {
         vector_layers: infos[uri].vector_layers
     };
     this.stats = {};
+    this.closeCalled = false;
     return callback && callback(null, this);
 };
 
@@ -167,4 +168,9 @@ Testsource.prototype.getTile = function(z,x,y,callback) {
 
 Testsource.prototype.getInfo = function(callback) {
     return callback(null, this.data);
+};
+
+Testsource.prototype.close = function(callback) {
+    this.closeCalled = true;
+    return callback(null);
 };


### PR DESCRIPTION
Call `close` is called on the source if the Vector source is closed. Provides ability to do a proper cleanup in the source used to retrieve the data from.

Without this, `tilelive-copy` will not terminate after copying if the source has any open resources, such as database connection.