### PR TITLE
Pass through backend params

### DIFF
--- a/test/testsource.js
+++ b/test/testsource.js
@@ -157,6 +157,17 @@ function Testsource(uri, callback) {
 
 Testsource.prototype.getTile = function(z,x,y,callback) {
     var key = [z,x,y].join('.');
+    if (callback.scale == undefined) {
+        return callback(new Error("Expected the callback to carry through scale option"));
+    }
+
+    if (callback.legacy == undefined) {
+        return callback(new Error("Expected the callback to carry through legacy option"));
+    }
+
+    if (callback.upgrade == undefined) {
+        return callback(new Error("Expected the callback to carry through upgrade option"));
+    }
 
     // Count number of times each key is requested for tests.
     this.stats[key] = this.stats[key] || 0;


### PR DESCRIPTION
There is a usage I've noticed of tilelive-vector sources in mapbox-maps where the callback to `getTile` has custom properties set on it.

The properties, like `scale`, `legacy`, and `upgrade` appear critical for controlling behavior in tilelive-vector.

These properties get lost when the backend is used (like when an `xray` source is created). The particular case I noticed, along with @dnomadb, is when the `scale` is expected to be available on the callback as a property, but it is not.

This fixes the problem by attaching the properties to `sourceGet` inside the backend. Then they are magically able to trickle through.

This PR also adds tests to ensure this is working within tilelive-vector.

I think this fix is correct. At the same time I've found it very difficult, to near impossible, to follow the flow of callbacks that, before this fix, resulted in the loss of the properties. The particular case I debugged was where a custom source was:

  - calling an array of other `tilelive-vector` sources
  - those "sub" sources were called themselves
  - the first call to the "sub" source had access to the properties
  - the second call did not

This fix makes it so the second call does actually still have access to the properties.