### PR TITLE
Remove incorrect comment - caching was removed in #43

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -45,7 +45,6 @@ Backend.prototype.getInfo = function(callback) {
     this._source.getInfo(callback);
 };
 
-// Wrapper around backend.getTile that implements a "locking" cache.
 Backend.prototype.getTile = function(z, x, y, callback) {
     if (!this._source) return callback(new Error('Tilesource not loaded'));
     if (z < 0 || x < 0 || y < 0 || x >= Math.pow(2,z) || y >= Math.pow(2,z)) {


### PR DESCRIPTION
The comment in `backend.js` of:

> Wrapper around backend.getTile that implements a "locking" cache.

Is incorrect. I tracked down that:

 - The "locking" cache was removed in https://github.com/mapbox/tilelive-vector/pull/43
 - The comment was also a copy and paste error from https://github.com/mapbox/tilelive-vector/commit/d9120e12755abb1d19f6f0d9eab712be4a84a049#diff-168726dbe96b3ce427e7fedce31bb0bcL112. It should have been removed at the time since the code was moved to the backend (so the code it refers to is now on the backend).

So, this PR removes the comment to avoid confusion for my future self / others.