### PR TITLE
update etag algorithm

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -86,9 +86,9 @@ Backend.prototype.getTile = function(z, x, y, callback) {
         headers['Last-Modified'] = new Date(headers['Last-Modified'] || 0).toUTCString();
 
         // Set an ETag if not present.
-        headers['ETag'] = headers['ETag'] || JSON.stringify(crypto.createHash('md5')
-            .update((z+','+x+','+y) + (data||''))
-            .digest('hex'));
+        headers['ETag'] = headers['ETag'] || crypto.createHash('md5')
+            .update((z+','+x+','+y) + (data && data.toString('binary')||''), 'utf8')
+            .digest('hex');
 
         // Set content type.
         headers['Content-Type'] = 'application/x-protobuf';
@@ -209,4 +209,3 @@ Backend.prototype.queryTile = function(z, lon, lat, options, callback) {
         });
     });
 };
-

--- a/backend.js
+++ b/backend.js
@@ -86,9 +86,9 @@ Backend.prototype.getTile = function(z, x, y, callback) {
         headers['Last-Modified'] = new Date(headers['Last-Modified'] || 0).toUTCString();
 
         // Set an ETag if not present.
-        headers['ETag'] = headers['ETag'] || crypto.createHash('md5')
+        headers['ETag'] = headers['ETag'] || JSON.stringify(crypto.createHash('md5')
             .update((z+','+x+','+y) + (data && data.toString('binary')||''), 'utf8')
-            .digest('hex');
+            .digest('hex'));
 
         // Set content type.
         headers['Content-Type'] = 'application/x-protobuf';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tilelive-vector",
-  "version": "4.1.0",
+  "version": "4.1.1-dev1",
   "main": "./index.js",
   "description": "Vector tile => raster tile backend for tilelive",
   "repository": {


### PR DESCRIPTION
This updates the ETag calculation to convert the data buffer to a string explicitly from a binary encoding since these are all protocol buffer vector tiles. Without this, `Buffer.toString()` (or the concatenation of buffers and strings) defaults to utf8, which results in different length buffers between node versions and therefore different etags between node versions, which should not be the case.

cc @mapbox/maps-api @springmeyer 